### PR TITLE
(chore) Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.3.1"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 readme = "README.md"
-homepage = "https://github.com/libctf/sdk"
+repository = "https://github.com/libctf/sdk"
 keywords = ["sdk", "ctf"]
 categories = ["api-bindings", "config", "web-programming"]
 


### PR DESCRIPTION
More explanation: https://github.com/szabgab/rust-digger/issues/88